### PR TITLE
Add makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 
-ERB_SOURCES = $(wildcard colors/*.erb)
-VIM_OUTPUTS = $(ERB_SOURCES:%.erb=%.vim)
+VIM_OUTPUTS = $(patsubst %.erb,%.vim,$(wildcard colors/*.erb))
 
 .PHONY: all
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+
+ERB_SOURCES = $(wildcard colors/*.erb)
+VIM_OUTPUTS = $(ERB_SOURCES:%.erb=%.vim)
+
+.PHONY: all
+
+all: $(VIM_OUTPUTS)
+
+%.vim: %.erb
+	erb -T - $< > $@


### PR DESCRIPTION
This makefile is generalized so that it should work even if the user
adds or renames the .erb template file(s).

Users should be able to simply run `make` to generate corresponding *.vim files from any *.erb templates in the colors/ dir.