### PR TITLE
Add comment about combining styles in highlight group

### DIFF
--- a/colors/rnb.erb
+++ b/colors/rnb.erb
@@ -86,7 +86,7 @@
     #     white,          the color used for background color, or use "NONE", "fg" or "bg"
     #     darkgray,       the color used for foreground color, or use "NONE", "fg" or "bg"
     #     "NONE"          style, can be "bold", "underline", "reverse", "italic",
-    #                     "standout", "NONE" or "undercurl"
+    #                     "standout", "NONE" or "undercurl" or a combination "underline,bold"
     #   ]
     #
     # The sample above tells Vim to render normal text in dark gray against a white


### PR DESCRIPTION
I struggled with combining different styles in a highlight group a bit until landing on [this post](https://vi.stackexchange.com/questions/14544/how-to-set-value-of-cterm-to-both-bold-and-underline?newreg=fbb8a6c143484b1ba9db0d51c4083feb). I figured other people might benefit.

Feel free to propose changes for the exact contents of the comment 😆