### PR TITLE
Adding tutorial to generate .erb to .vim

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,23 +24,17 @@ The process is divided in five steps:
 2. start by editing your colorscheme's information,
 3. define your colors,
 4. define your highlight groups and links,
-5. and generate your colorscheme (refer next step below).
+5. and generate your colorscheme (refer [how to generate](https://github.com/romainl/vim-rnb/blob/009cedd755ae1eeabe8842a320035f73459d39dd/colors/rnb.erb#L242)).
 
-Steps 2 to 5 are thoroughly described in the colorscheme template itself in an effort to make it portable: if you ever decide to distribute your colorscheme you can simply package the template with it.
+Steps 2 to 5 are thoroughly described in the [colorscheme template](https://github.com/romainl/vim-rnb/blob/master/colors/rnb.erb) itself in an effort to make it portable: if you ever decide to distribute your colorscheme you can simply package the template with it.
 
-## How to Generate?
+## Necessary Tool:
 
-you need to have ruby installed `sudo apt install ruby` before get started.
-
-1. clone this repo.
-2. cd `./vim-rbn/`
-3. type `make` in terminal
-
-the generated file will be in `./vim-rbn/colors/` with the `.vim` file extension.  
-move it to:  
-- vim: `~/.vim/colors/`
-- nvim: `~/.config/nvim/colors/`
-
+you need to have ruby installed before get started: 
+- apt (Debian or Ubuntu): `sudo apt install ruby`  
+- pacman (Arch Linux): `sudo pacman -S ruby`
+- Homebrew (macOS): `brew install ruby`
+- FreeBSD: `pkg install ruby`
 
 ## Built with RNB
 

--- a/README.md
+++ b/README.md
@@ -24,9 +24,23 @@ The process is divided in five steps:
 2. start by editing your colorscheme's information,
 3. define your colors,
 4. define your highlight groups and links,
-5. and generate your colorscheme.
+5. and generate your colorscheme (refer next step below).
 
 Steps 2 to 5 are thoroughly described in the colorscheme template itself in an effort to make it portable: if you ever decide to distribute your colorscheme you can simply package the template with it.
+
+## How to Generate?
+
+you need to have ruby installed `sudo apt install ruby` before get started.
+
+1. clone this repo.
+2. cd `./vim-rbn/`
+3. type `make` in terminal
+
+the generated file will be in `./vim-rbn/colors/` with the `.vim` file extension.  
+move it to:  
+- vim: `~/.vim/colors/`
+- nvim: `~/.config/nvim/colors/`
+
 
 ## Built with RNB
 


### PR DESCRIPTION
as a guy who never uses ruby it is pain in the ass looking for anywhere how to convert the template engine (.erb) to (.vim). I thought it simply by just `erb rnb.erb > rnb.vim` and done but in fact *it's not*

so adding this I hope could reduce someone else to look for over the internet how to generate while the answer is very simple