### PR TITLE
Add Raider.vim colour scheme to "built with RNB" list

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ The following colorschemes are known to be built with RNB:
 * [antarctic](https://sr.ht/~swalladge/antarctic-vim/)
 * [Stella](https://github.com/Shrimpram/vim-stella)
 * [Outrun](https://github.com/u03c1/outrun-vim)
+* [Raider](https://github.com/axvr/raider.vim)
 * (your colorscheme here, send us a PR!)
 
 ## TODO


### PR DESCRIPTION
Adds my new colour scheme [Raider.vim](https://github.com/axvr/raider.vim) to the "built with RNB" list.